### PR TITLE
Расположение детекторов по дуге слоя

### DIFF
--- a/src/main/kotlin/viz.kt
+++ b/src/main/kotlin/viz.kt
@@ -139,7 +139,7 @@ fun SlidingWindowAngleEncoder.drawDetectorsPdf(
         if (markAngleDeg != null) {
             val layerCount = layers.size.coerceAtLeast(1)
             layers.forEachIndexed { layerIndex, layer ->
-                val centerStepRadians = fullCircleInRadians / layer.detectorCount
+                val centerStepRadians = (layer.arcLengthDegrees) * Math.PI / 180.0
                 val centerStepDeg = Math.toDegrees(centerStepRadians)
                 val layerPhaseRadians = (layerIndex.toDouble() / layerCount) * centerStepRadians
                 val layerPhaseDeg = Math.toDegrees(layerPhaseRadians)
@@ -164,7 +164,7 @@ fun SlidingWindowAngleEncoder.drawDetectorsPdf(
         layers.forEach { layer ->
             val color = layerColors[layerIndex % layerColors.size]
 
-            val centerStepRadians = fullCircleInRadians / layer.detectorCount
+            val centerStepRadians = (layer.arcLengthDegrees) * Math.PI / 180.0
             val centerStepDeg = Math.toDegrees(centerStepRadians)
             val layerPhaseRadians = (layerIndex.toDouble() / layerCount) * centerStepRadians
             val layerPhaseDeg = Math.toDegrees(layerPhaseRadians)


### PR DESCRIPTION
## Резюме
- пересчитал шаг центров детекторов на основе длины дуги слоя и обновил документацию
- скорректировал визуализацию PDF, чтобы использовать тот же шаг при подсветке и отрисовке

## Тестирование
- bash ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d50c6d1168832e8ae016a88e800e54