### PR TITLE
Добавить визуализацию корреляции нулевого угла

### DIFF
--- a/src/main/kotlin/BackgroundCorrelationAnalyzer.kt
+++ b/src/main/kotlin/BackgroundCorrelationAnalyzer.kt
@@ -83,9 +83,9 @@ class BackgroundCorrelationAnalyzer {
      * для нулевого угла. Визуализация повторяет подход из разд. 2.2.4.1 DAML, где подчёркнута
      * важность контроля паразитной схожести между кодами.
      */
-    fun analyzeWithAngles(codes: Collection<Pair<Double, IntArray>>): Stats {
+    fun analyzeWithAngles(codes: Collection<Pair<Double, IntArray>>, angle: Double): Stats {
         val stats = analyze(codes.map { it.second })
-        printCorrelationProfile(referenceAngleDegrees = 0.0, codesWithAngles = codes)
+        printCorrelationProfile(referenceAngleDegrees = angle, codesWithAngles = codes)
         return stats
     }
 
@@ -130,7 +130,7 @@ class BackgroundCorrelationAnalyzer {
         val scale = if (maxCorrelation == 0.0) 0.0 else 40.0 / maxCorrelation
 
         println(
-            "Профиль корреляции для угла ${formatAngle(reference.angleDegrees)}° (по канону DAML):"
+            "Профиль корреляции для угла ${formatAngle(reference.angleDegrees)}°:"
         )
 
         profile.forEach { (angleDegrees, correlation) ->

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -14,12 +14,12 @@ fun main() {
     (0..359).forEach {
         val angleRadians = it * PI / 180.0
         val code = encoder.encode(angleRadians)
-//        println(code.joinToString("", "[", "]") + ":$it")
+        println(code.joinToString("", "[", "]") + ":$it")
 //        encoder.drawDetectorsPdf("./detectors.pdf", markAngleRadians = angleRadians)
     }
 
     val backgroundCorrelationAnalyzer = BackgroundCorrelationAnalyzer()
-    val results = backgroundCorrelationAnalyzer.analyzeWithAngles(encoder.codes)
+    val results = backgroundCorrelationAnalyzer.analyzeWithAngles(encoder.codes, 180.0)
 
     println("Done")
 


### PR DESCRIPTION
## Изменения
- добавил перегрузку анализатора для работы с парами (угол, код) и выводом профиля корреляции нулевого угла
- реализовал печать текстового графика корреляции и вспомогательные функции нормализации углов
- обновил пример использования в Main.kt для вызова нового метода

## Тестирование
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d68571d830832e85722892bbf0ad07