### PR TITLE
Добавить график профиля корреляции в PDF визуализации

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -21,6 +21,12 @@ fun main() {
     val backgroundCorrelationAnalyzer = BackgroundCorrelationAnalyzer()
     val results = backgroundCorrelationAnalyzer.analyzeWithAngles(encoder.codes, 180.0)
 
+    encoder.drawDetectorsPdf(
+        "./detectors.pdf",
+        markAngleRadians = PI,
+        correlationProfile = results.correlationProfile
+    )
+
     println("Done")
 
 }


### PR DESCRIPTION
## Описание
- добавлен возврат профиля корреляции из BackgroundCorrelationAnalyzer и передача его в визуализацию
- расширена drawDetectorsPdf поддержкой графика профиля корреляции и вертикальной метки опорного угла
- пример в Main.kt теперь сохраняет PDF с профилем корреляции

## Тестирование
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d695e76c10832e9db33d0e8d9f904f