### PR TITLE
Добавлен график корреляции в PDF визуализации

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -15,11 +15,22 @@ fun main() {
         val angleRadians = it * PI / 180.0
         val code = encoder.encode(angleRadians)
         println(code.joinToString("", "[", "]") + ":$it")
-//        encoder.drawDetectorsPdf("./detectors.pdf", markAngleRadians = angleRadians)
     }
 
     val backgroundCorrelationAnalyzer = BackgroundCorrelationAnalyzer()
-    val results = backgroundCorrelationAnalyzer.analyzeWithAngles(encoder.codes, 180.0)
+    val analysis = backgroundCorrelationAnalyzer.analyzeWithAngles(encoder.codes, 180.0)
+    val stats = analysis.stats
+    println("Mean correlation: ${stats.meanCorrelation}")
+    println("Max correlation: ${stats.maxCorrelation}")
+
+    analysis.correlationProfile?.let { profile ->
+        val referenceRadians = Math.toRadians(profile.referenceAngleDegrees)
+        encoder.drawDetectorsPdf(
+            "./detectors.pdf",
+            markAngleRadians = referenceRadians,
+            correlationProfile = profile
+        )
+    }
 
     println("Done")
 


### PR DESCRIPTION
## Резюме
- вынес профиль корреляции в отдельные структуры данных и вернул его из BackgroundCorrelationAnalyzer
- добавил построение графика профиля корреляции на каждой странице drawDetectorsPdf и автоматический расчёт данных
- обновил пример в Main для сохранения PDF с графиком и вывода статистики по корреляции

## Тестирование
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d699828308832ea0568f659ac2bcfd