### PR TITLE
Добавлен класс DampLayout2D для канонической раскладки кодов

### DIFF
--- a/src/main/kotlin/DampLayout2D.kt
+++ b/src/main/kotlin/DampLayout2D.kt
@@ -196,7 +196,11 @@ class DampLayout2D(
         var total = 0.0
         for (y in 0 until height) {
             for (x in 0 until width) {
-                val idx = grid[y][x] ?: continue
+                val idx = when {
+                    y == y1 && x == x1 -> firstIndex
+                    y == y2 && x == x2 -> secondIndex
+                    else -> grid[y][x]
+                } ?: continue
                 val s1 = similarityWithThreshold(firstIndex, idx, lambda)
                 val s2 = similarityWithThreshold(secondIndex, idx, lambda)
                 if (s1 == 0.0 && s2 == 0.0) continue
@@ -233,7 +237,11 @@ class DampLayout2D(
                 val dxCenter = x - cx
                 val centerDistanceSquared = dyCenterSquared + dxCenter * dxCenter
                 if (centerDistanceSquared > radiusSquared) continue
-                val idx = grid[y][x]
+                val idx = when {
+                    y == y1 && x == x1 -> firstIndex
+                    y == y2 && x == x2 -> secondIndex
+                    else -> grid[y][x]
+                } ?: continue
                 val s1 = similarityWithThreshold(firstIndex, idx, lambda)
                 val s2 = similarityWithThreshold(secondIndex, idx, lambda)
                 if (s1 == 0.0 && s2 == 0.0) continue

--- a/src/main/kotlin/DampLayout2D.kt
+++ b/src/main/kotlin/DampLayout2D.kt
@@ -1,0 +1,332 @@
+import kotlin.math.ceil
+import kotlin.math.exp
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.sqrt
+import kotlin.random.Random
+
+/**
+ * DampLayout2D — дискретная 2D-раскладка кодов по канону главы 5 DAML.
+ *
+ * Алгоритм реализует этапы, описанные в разд. 5.5–5.9 и п. 7.1.7:
+ * 1) формирование матрицы 𝐕 с запасом ≈15 % свободных ячеек (d² ≈ n ⋅ 1.15);
+ * 2) случайная начальная раскладка кодов по ячейкам (рис. 17а);
+ * 3) итеративный дальний (long-range) этап: минимизация энергии 𝜑 через обмен пар
+ *    точек, выбранных в радиусе r, с пороговой метрикой sim𝜆 (формулы 5.5.1);
+ * 4) последовательное ужесточение порога 𝜆 и сжатие радиуса r, как рекомендовалось
+ *    для морфологического эксперимента (п. 7.1.7);
+ * 5) ближний (short-range) этап: максимизация локальной энергии по (5.5.2) внутри
+ *    окрестности 𝐑 пары точек.
+ *
+ * Входные коды трактуются как разрежённые битовые векторы, для меры близости
+ * применяется дискретный косинус (разд. 2.2.4.1) с пороговой функцией 𝜏(x).
+ */
+class DampLayout2D(
+    private val codes: List<IntArray>,
+    private val parameters: Parameters = Parameters(),
+    random: Random? = null,
+) {
+    /** Параметры раскладки, повторяющие канон статьи. */
+    data class Parameters(
+        val marginFraction: Double = 0.15, // запас пустых ячеек ≈15 % (п. 7.1.7)
+        val lambdaStart: Double = 0.65,    // начальное 𝜆 (п. 7.1.7)
+        val lambdaEnd: Double = 0.8,       // конечное 𝜆 (п. 7.1.7)
+        val lambdaStep: Double = 0.05,     // шаг ужесточения порога
+        val eta: Double = Double.POSITIVE_INFINITY, // 𝜂 = ∞ — жёсткий отсев (п. 7.1.7)
+        val initialRadiusFraction: Double = 0.5,    // стартовый радиус r = d / 2
+        val radiusDecayFactor: Double = 0.5,        // уменьшение радиуса при стагнации
+        val minRadius: Double = 1.0,                // минимальный радиус отбора пар
+        val pairCountPerStep: Int? = null,          // 𝑝 — число тестовых пар за шаг
+        val maxLongRangeSteps: Int = 50,
+        val maxShortRangeSteps: Int = 30,
+        val swapRatioThreshold: Double = 0.01,      // порог 1 % от начального обмена (п. 7.1.7)
+        val shortRangeBaseRadius: Double = 2.0,     // базовый радиус для ближнего этапа
+    )
+
+    private val rnd: Random = random ?: Random.Default
+    private val vectorLength: Int
+    private val norms: DoubleArray
+
+    private lateinit var grid: Array<Array<Int?>> // матрица 𝐕 (индексы кодов или null)
+    private lateinit var positions: Array<IntArray> // координаты кодов в матрице
+    private var height: Int = 0
+    private var width: Int = 0
+
+    init {
+        require(codes.isNotEmpty()) { "Список кодов не может быть пустым" }
+        vectorLength = codes.first().size
+        require(codes.all { it.size == vectorLength }) {
+            "Все коды должны иметь одинаковую длину"
+        }
+        require(vectorLength > 0) { "Код не может иметь нулевую длину" }
+        norms = DoubleArray(codes.size) { index ->
+            val ones = codes[index].count { it != 0 }
+            if (ones == 0) 0.0 else sqrt(ones.toDouble())
+        }
+    }
+
+    /**
+     * Запускает полный цикл раскладки и возвращает финальную матрицу 𝐕.
+     * Ячейки без кода представлены значением null.
+     */
+    fun layout(): List<List<IntArray?>> {
+        initialiseMatrix()
+        performLongRangePhase()
+        performShortRangePhase()
+        return buildResult()
+    }
+
+    private fun initialiseMatrix() {
+        val codeCount = codes.size
+        val totalSlots = ceil(codeCount * (1.0 + parameters.marginFraction)).toInt().coerceAtLeast(codeCount)
+        val side = ceil(sqrt(totalSlots.toDouble())).toInt().coerceAtLeast(1)
+        height = side
+        width = side
+        grid = Array(height) { arrayOfNulls<Int?>(width) }
+        positions = Array(codes.size) { IntArray(2) }
+
+        // Случайно распределяем коды по ячейкам (рис. 17а).
+        val slots = MutableList(height * width) { it }
+        slots.shuffle(rnd)
+        codes.indices.forEach { codeIndex ->
+            val slot = slots[codeIndex]
+            val y = slot / width
+            val x = slot % width
+            grid[y][x] = codeIndex
+            positions[codeIndex][0] = y
+            positions[codeIndex][1] = x
+        }
+    }
+
+    private fun performLongRangePhase() {
+        var lambda = parameters.lambdaStart
+        var radius = max(parameters.minRadius, max(height, width) * parameters.initialRadiusFraction)
+        val pairCount = max(1, parameters.pairCountPerStep ?: codes.size)
+        var baselineSwaps: Double? = null
+
+        for (step in 0 until parameters.maxLongRangeSteps) {
+            var swaps = 0
+            repeat(pairCount) {
+                val pair = pickPair(radius) ?: return@repeat
+                val (first, second) = pair
+                val firstIndex = grid[first.first][first.second]
+                val secondIndex = grid[second.first][second.second]
+                val currentEnergy = computeLongRangeEnergy(firstIndex, first.first, first.second, secondIndex, second.first, second.second, lambda)
+                val swappedEnergy = computeLongRangeEnergy(secondIndex, first.first, first.second, firstIndex, second.first, second.second, lambda)
+                if (swappedEnergy < currentEnergy) {
+                    swapCells(first, second)
+                    swaps++
+                }
+            }
+            if (baselineSwaps == null) {
+                baselineSwaps = swaps.toDouble().coerceAtLeast(1.0)
+            }
+            if (swaps == 0) {
+                val lambdaChanged = if (lambda < parameters.lambdaEnd) {
+                    lambda = min(lambda + parameters.lambdaStep, parameters.lambdaEnd)
+                    true
+                } else false
+                val radiusChanged = if (radius > parameters.minRadius) {
+                    radius = max(radius * parameters.radiusDecayFactor, parameters.minRadius)
+                    true
+                } else false
+                if (!lambdaChanged && !radiusChanged) break
+                continue
+            }
+            val target = baselineSwaps!! * parameters.swapRatioThreshold
+            if (swaps <= target) {
+                if (lambda < parameters.lambdaEnd) {
+                    lambda = min(lambda + parameters.lambdaStep, parameters.lambdaEnd)
+                }
+                if (radius > parameters.minRadius) {
+                    radius = max(radius * parameters.radiusDecayFactor, parameters.minRadius)
+                }
+            }
+            if (lambda >= parameters.lambdaEnd && radius <= parameters.minRadius) break
+        }
+    }
+
+    private fun performShortRangePhase() {
+        val pairCount = max(1, parameters.pairCountPerStep ?: codes.size)
+        val lambda = parameters.lambdaEnd
+        val baseRadius = parameters.shortRangeBaseRadius
+
+        for (step in 0 until parameters.maxShortRangeSteps) {
+            var swaps = 0
+            repeat(pairCount) {
+                val pair = pickPair(max(baseRadius, parameters.minRadius)) ?: return@repeat
+                val (first, second) = pair
+                val firstIndex = grid[first.first][first.second]
+                val secondIndex = grid[second.first][second.second]
+                val distance = sqrt(distanceSquared(first.first, first.second, second.first, second.second))
+                val radius = max(baseRadius, distance)
+                val currentEnergy = computeShortRangeEnergy(firstIndex, first.first, first.second, secondIndex, second.first, second.second, lambda, radius)
+                val swappedEnergy = computeShortRangeEnergy(secondIndex, first.first, first.second, firstIndex, second.first, second.second, lambda, radius)
+                if (swappedEnergy > currentEnergy) {
+                    swapCells(first, second)
+                    swaps++
+                }
+            }
+            if (swaps == 0) break
+        }
+    }
+
+    private fun computeLongRangeEnergy(
+        firstIndex: Int?,
+        y1: Int,
+        x1: Int,
+        secondIndex: Int?,
+        y2: Int,
+        x2: Int,
+        lambda: Double,
+    ): Double {
+        var total = 0.0
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                val idx = grid[y][x] ?: continue
+                val s1 = similarityWithThreshold(firstIndex, idx, lambda)
+                val s2 = similarityWithThreshold(secondIndex, idx, lambda)
+                if (s1 == 0.0 && s2 == 0.0) continue
+                val d1 = distanceSquared(y1, x1, y, x)
+                val d2 = distanceSquared(y2, x2, y, x)
+                total += s1 * d1 + s2 * d2
+            }
+        }
+        return total
+    }
+
+    private fun computeShortRangeEnergy(
+        firstIndex: Int?,
+        y1: Int,
+        x1: Int,
+        secondIndex: Int?,
+        y2: Int,
+        x2: Int,
+        lambda: Double,
+        radius: Double,
+    ): Double {
+        val cy = (y1 + y2) / 2.0
+        val cx = (x1 + x2) / 2.0
+        val radiusSquared = radius * radius
+        val minY = max(0, kotlin.math.floor(cy - radius).toInt())
+        val maxY = min(height - 1, kotlin.math.ceil(cy + radius).toInt())
+        val minX = max(0, kotlin.math.floor(cx - radius).toInt())
+        val maxX = min(width - 1, kotlin.math.ceil(cx + radius).toInt())
+        var total = 0.0
+        for (y in minY..maxY) {
+            val dyCenter = y - cy
+            val dyCenterSquared = dyCenter * dyCenter
+            for (x in minX..maxX) {
+                val dxCenter = x - cx
+                val centerDistanceSquared = dyCenterSquared + dxCenter * dxCenter
+                if (centerDistanceSquared > radiusSquared) continue
+                val idx = grid[y][x]
+                val s1 = similarityWithThreshold(firstIndex, idx, lambda)
+                val s2 = similarityWithThreshold(secondIndex, idx, lambda)
+                if (s1 == 0.0 && s2 == 0.0) continue
+                val d1 = max(distanceSquared(y1, x1, y, x), 1e-9)
+                val d2 = max(distanceSquared(y2, x2, y, x), 1e-9)
+                total += s1 / d1 + s2 / d2
+            }
+        }
+        return total
+    }
+
+    private fun similarityWithThreshold(firstIndex: Int?, secondIndex: Int?, lambda: Double): Double {
+        if (firstIndex == null || secondIndex == null) return 0.0
+        val raw = rawSimilarity(firstIndex, secondIndex)
+        if (raw <= 0.0) return 0.0
+        return applyThreshold(raw, lambda)
+    }
+
+    private fun rawSimilarity(aIndex: Int, bIndex: Int): Double {
+        if (aIndex == bIndex) return 1.0
+        val normA = norms[aIndex]
+        val normB = norms[bIndex]
+        if (normA == 0.0 || normB == 0.0) return 0.0
+        val a = codes[aIndex]
+        val b = codes[bIndex]
+        var intersection = 0
+        for (i in 0 until vectorLength) {
+            if (a[i] != 0 && b[i] != 0) {
+                intersection++
+            }
+        }
+        return intersection / (normA * normB)
+    }
+
+    private fun applyThreshold(raw: Double, lambda: Double): Double {
+        return if (parameters.eta.isInfinite()) {
+            if (raw >= lambda) raw else 0.0
+        } else {
+            val sigma = 1.0 / (1.0 + exp(-parameters.eta * (raw - lambda)))
+            raw * sigma
+        }
+    }
+
+    private fun pickPair(radius: Double): Pair<Pair<Int, Int>, Pair<Int, Int>>? {
+        val firstIndex = rnd.nextInt(codes.size)
+        val y1 = positions[firstIndex][0]
+        val x1 = positions[firstIndex][1]
+        val second = pickNeighbour(y1, x1, radius) ?: return null
+        return (y1 to x1) to second
+    }
+
+    private fun pickNeighbour(y1: Int, x1: Int, radius: Double): Pair<Int, Int>? {
+        val radiusAdjusted = max(radius, 1.0)
+        val radiusSquared = radiusAdjusted * radiusAdjusted
+        val minY = max(0, kotlin.math.floor(y1 - radiusAdjusted).toInt())
+        val maxY = min(height - 1, kotlin.math.ceil(y1 + radiusAdjusted).toInt())
+        val minX = max(0, kotlin.math.floor(x1 - radiusAdjusted).toInt())
+        val maxX = min(width - 1, kotlin.math.ceil(x1 + radiusAdjusted).toInt())
+        var chosen: Pair<Int, Int>? = null
+        var seen = 0
+        for (y in minY..maxY) {
+            val dy = (y - y1).toDouble()
+            val dySquared = dy * dy
+            for (x in minX..maxX) {
+                if (y == y1 && x == x1) continue
+                val dx = (x - x1).toDouble()
+                val distanceSquared = dySquared + dx * dx
+                if (distanceSquared > radiusSquared) continue
+                seen++
+                if (rnd.nextInt(seen) == 0) {
+                    chosen = y to x
+                }
+            }
+        }
+        return chosen
+    }
+
+    private fun swapCells(first: Pair<Int, Int>, second: Pair<Int, Int>) {
+        val (y1, x1) = first
+        val (y2, x2) = second
+        val firstIndex = grid[y1][x1]
+        val secondIndex = grid[y2][x2]
+        grid[y1][x1] = secondIndex
+        grid[y2][x2] = firstIndex
+        if (firstIndex != null) {
+            positions[firstIndex][0] = y2
+            positions[firstIndex][1] = x2
+        }
+        if (secondIndex != null) {
+            positions[secondIndex][0] = y1
+            positions[secondIndex][1] = x1
+        }
+    }
+
+    private fun distanceSquared(y1: Int, x1: Int, y2: Int, x2: Int): Double {
+        val dy = (y1 - y2).toDouble()
+        val dx = (x1 - x2).toDouble()
+        return dy * dy + dx * dx
+    }
+
+    private fun buildResult(): List<List<IntArray?>> {
+        return List(height) { y ->
+            List(width) { x ->
+                val index = grid[y][x]
+                index?.let { codes[it].copyOf() }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/DampLayoutVisualization.kt
+++ b/src/main/kotlin/DampLayoutVisualization.kt
@@ -1,0 +1,66 @@
+import kotlin.math.PI
+
+/**
+ * DampLayoutVisualization описывает каноническую 2D-раскладку кодов согласно разд. 5.5 DAML.
+ */
+data class DampLayoutVisualization(
+    val width: Int,
+    val height: Int,
+    val points: List<Point>,
+) {
+    data class Point(val x: Int, val y: Int, val angleDegrees: Double)
+}
+
+/**
+ * Формирует визуализацию канонической раскладки по статье DAML: сначала строится список кодов,
+ * затем применяется алгоритм DampLayout2D, а результат переводится в координаты с привязкой к углам.
+ */
+fun buildDampLayoutVisualization(
+    samples: List<Pair<Double, IntArray>>,
+    parameters: DampLayout2D.Parameters = DampLayout2D.Parameters()
+): DampLayoutVisualization {
+    require(samples.isNotEmpty()) { "Нужно предоставить хотя бы один код для раскладки" }
+
+    val signatureToAngle = HashMap<String, Double>(samples.size)
+    samples.forEach { (angleRadians, code) ->
+        val angleDegrees = normalizeDegrees((angleRadians * 180.0) / PI)
+        val signature = codeSignature(code)
+        signatureToAngle.putIfAbsent(signature, angleDegrees)
+    }
+
+    val codes = samples.map { it.second }
+    val layoutMatrix = DampLayout2D(codes, parameters).layout()
+    val height = layoutMatrix.size
+    val width = layoutMatrix.firstOrNull()?.size ?: 0
+
+    val points = mutableListOf<DampLayoutVisualization.Point>()
+    layoutMatrix.forEachIndexed { y, row ->
+        row.forEachIndexed { x, code ->
+            if (code != null) {
+                val signature = codeSignature(code)
+                val angle = signatureToAngle[signature]
+                    ?: error("Не удалось сопоставить угол для кода с подписью $signature")
+                points += DampLayoutVisualization.Point(x, y, angle)
+            }
+        }
+    }
+
+    return DampLayoutVisualization(width, height, points)
+}
+
+private fun codeSignature(code: IntArray): String {
+    val builder = StringBuilder()
+    code.forEachIndexed { index, value ->
+        if (value != 0) {
+            if (builder.isNotEmpty()) builder.append(',')
+            builder.append(index)
+        }
+    }
+    return builder.toString()
+}
+
+private fun normalizeDegrees(angle: Double): Double {
+    var result = angle % 360.0
+    if (result < 0.0) result += 360.0
+    return result
+}

--- a/src/main/kotlin/DetectorsUi.kt
+++ b/src/main/kotlin/DetectorsUi.kt
@@ -647,7 +647,7 @@ private fun buildCorrelationSvg(profile: BackgroundCorrelationAnalyzer.Correlati
 
 private fun buildLayoutSvg(layout: DampLayoutVisualization): String {
     if (layout.width <= 0 || layout.height <= 0) {
-        return """<svg viewBox=\"0 0 120 80\" width=\"120\" height=\"80\" xmlns=\"http://www.w3.org/2000/svg\"><text x=\"60\" y=\"45\" fill=\"#6b7280\" font-size=\"12\" text-anchor=\"middle\">Нет данных</text></svg>"""
+        return """<svg viewBox="0 0 120 80" width="120" height="80" xmlns="http://www.w3.org/2000/svg"><text x="60" y="45" fill="#6b7280" font-size="12" text-anchor="middle">Нет данных</text></svg>"""
     }
 
     val cellSize = 18.0
@@ -658,9 +658,9 @@ private fun buildLayoutSvg(layout: DampLayoutVisualization): String {
     val occupancy = layout.points.associateBy { it.x to it.y }
 
     val builder = StringBuilder()
-    builder.appendLine("""<svg viewBox=\"0 0 ${fmt(svgWidth)} ${fmt(svgHeight)}\" width=\"${fmt(svgWidth)}\" height=\"${fmt(svgHeight)}\" xmlns=\"http://www.w3.org/2000/svg\">""")
-    builder.appendLine("""<rect x=\"0\" y=\"0\" width=\"${fmt(svgWidth)}\" height=\"${fmt(svgHeight)}\" fill=\"#ffffff\" rx=\"18\"/>""")
-    builder.appendLine("""<g stroke=\"#e5e7eb\" stroke-width=\"0.6\">""")
+    builder.appendLine("""<svg viewBox="0 0 ${fmt(svgWidth)} ${fmt(svgHeight)}" width="${fmt(svgWidth)}" height="${fmt(svgHeight)}" xmlns="http://www.w3.org/2000/svg">""")
+    builder.appendLine("""<rect x="0" y="0" width="${fmt(svgWidth)}" height="${fmt(svgHeight)}" fill="#ffffff" rx="18"/>""")
+    builder.appendLine("""<g stroke="#e5e7eb" stroke-width="0.6">""")
     for (y in 0 until layout.height) {
         for (x in 0 until layout.width) {
             val top = padding + y * cellSize
@@ -668,19 +668,19 @@ private fun buildLayoutSvg(layout: DampLayoutVisualization): String {
             val occupied = occupancy.containsKey(x to y)
             val fill = if (occupied) "#f1f5f9" else "#ffffff"
             builder.appendLine(
-                """<rect x=\"${fmt(left)}\" y=\"${fmt(top)}\" width=\"${fmt(cellSize)}\" height=\"${fmt(cellSize)}\" fill=\"$fill\"/>"""
+                """<rect x="${fmt(left)}" y="${fmt(top)}" width="${fmt(cellSize)}" height="${fmt(cellSize)}" fill="$fill"/>"""
             )
         }
     }
     builder.appendLine("</g>")
-    builder.appendLine("""<g stroke=\"#111827\" stroke-width=\"0.4\">""")
+    builder.appendLine("""<g stroke="#111827" stroke-width="0.4">""")
 
     layout.points.forEach { point ->
         val cx = padding + (point.x + 0.5) * cellSize
         val cy = padding + (point.y + 0.5) * cellSize
         val color = hsvToHex(point.angleDegrees)
         builder.appendLine(
-            """<circle cx=\"${fmt(cx)}\" cy=\"${fmt(cy)}\" r=\"${fmt(pointRadius)}\" fill=\"$color\"/>"""
+            """<circle cx="${fmt(cx)}" cy="${fmt(cy)}" r="${fmt(pointRadius)}" fill="$color"/>"""
         )
     }
 

--- a/src/main/kotlin/DetectorsUi.kt
+++ b/src/main/kotlin/DetectorsUi.kt
@@ -679,8 +679,36 @@ private fun buildLayoutSvg(layout: DampLayoutVisualization): String {
         val cx = padding + (point.x + 0.5) * cellSize
         val cy = padding + (point.y + 0.5) * cellSize
         val color = hsvToHex(point.angleDegrees)
+
+        val angleRad = point.angleDegrees * PI / 180.0
+        val dirX = kotlin.math.cos(angleRad)
+        val dirY = -kotlin.math.sin(angleRad)
+        val arrowLength = cellSize * 0.6
+        val headLength = arrowLength * 0.25
+        val headWidth = headLength * 0.9
+
+        val startX = cx - dirX * (pointRadius * 0.2)
+        val startY = cy - dirY * (pointRadius * 0.2)
+        val endX = cx + dirX * arrowLength
+        val endY = cy + dirY * arrowLength
+
+        val baseX = endX - dirX * headLength
+        val baseY = endY - dirY * headLength
+        val normalX = -dirY
+        val normalY = dirX
+        val leftX = baseX + normalX * (headWidth / 2)
+        val leftY = baseY + normalY * (headWidth / 2)
+        val rightX = baseX - normalX * (headWidth / 2)
+        val rightY = baseY - normalY * (headWidth / 2)
+
         builder.appendLine(
             """<circle cx="${fmt(cx)}" cy="${fmt(cy)}" r="${fmt(pointRadius)}" fill="$color"/>"""
+        )
+        builder.appendLine(
+            """<line x1="${fmt(startX)}" y1="${fmt(startY)}" x2="${fmt(baseX)}" y2="${fmt(baseY)}" stroke="$color" stroke-width="1.2" stroke-linecap="round"/>"""
+        )
+        builder.appendLine(
+            """<polygon points="${fmt(endX)},${fmt(endY)} ${fmt(leftX)},${fmt(leftY)} ${fmt(rightX)},${fmt(rightY)}" fill="$color"/>"""
         )
     }
 

--- a/src/main/kotlin/DetectorsUi.kt
+++ b/src/main/kotlin/DetectorsUi.kt
@@ -651,24 +651,40 @@ private fun buildLayoutSvg(layout: DampLayoutVisualization): String {
     }
 
     val cellSize = 18.0
-    val padding = 28.0
+    val padding = 32.0
     val svgWidth = padding * 2 + layout.width * cellSize
     val svgHeight = padding * 2 + layout.height * cellSize
-    val pointRadius = cellSize * 0.35
+    val pointRadius = cellSize * 0.32
+    val occupancy = layout.points.associateBy { it.x to it.y }
 
     val builder = StringBuilder()
     builder.appendLine("""<svg viewBox=\"0 0 ${fmt(svgWidth)} ${fmt(svgHeight)}\" width=\"${fmt(svgWidth)}\" height=\"${fmt(svgHeight)}\" xmlns=\"http://www.w3.org/2000/svg\">""")
     builder.appendLine("""<rect x=\"0\" y=\"0\" width=\"${fmt(svgWidth)}\" height=\"${fmt(svgHeight)}\" fill=\"#ffffff\" rx=\"18\"/>""")
+    builder.appendLine("""<g stroke=\"#e5e7eb\" stroke-width=\"0.6\">""")
+    for (y in 0 until layout.height) {
+        for (x in 0 until layout.width) {
+            val top = padding + y * cellSize
+            val left = padding + x * cellSize
+            val occupied = occupancy.containsKey(x to y)
+            val fill = if (occupied) "#f1f5f9" else "#ffffff"
+            builder.appendLine(
+                """<rect x=\"${fmt(left)}\" y=\"${fmt(top)}\" width=\"${fmt(cellSize)}\" height=\"${fmt(cellSize)}\" fill=\"$fill\"/>"""
+            )
+        }
+    }
+    builder.appendLine("</g>")
+    builder.appendLine("""<g stroke=\"#111827\" stroke-width=\"0.4\">""")
 
     layout.points.forEach { point ->
         val cx = padding + (point.x + 0.5) * cellSize
         val cy = padding + (point.y + 0.5) * cellSize
         val color = hsvToHex(point.angleDegrees)
         builder.appendLine(
-            """<circle cx=\"${fmt(cx)}\" cy=\"${fmt(cy)}\" r=\"${fmt(pointRadius)}\" fill=\"$color\" stroke=\"#111827\" stroke-width=\"0.5\"/>"""
+            """<circle cx=\"${fmt(cx)}\" cy=\"${fmt(cy)}\" r=\"${fmt(pointRadius)}\" fill=\"$color\"/>"""
         )
     }
 
+    builder.appendLine("</g>")
     builder.appendLine("</svg>")
     return builder.toString()
 }

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -14,12 +14,16 @@ fun main() {
         initialCodeSizeInBits = 256
     )
 
+    val canonicalSamples = encoder.sampleFullCircle(stepDegrees = 1.0)
+    val layoutVisualization = buildDampLayoutVisualization(canonicalSamples)
     val backgroundCorrelationAnalyzer = BackgroundCorrelationAnalyzer()
 
     embeddedServer(Netty, port = 8080) {
         detectorsUiModule(
             encoder = encoder,
-            backgroundAnalyzer = backgroundCorrelationAnalyzer
+            backgroundAnalyzer = backgroundCorrelationAnalyzer,
+            initialCanonicalSamples = canonicalSamples,
+            initialLayout = layoutVisualization
         )
     }.start(wait = true)
 }

--- a/src/test/kotlin/DampLayout2DEnergyTest.kt
+++ b/src/test/kotlin/DampLayout2DEnergyTest.kt
@@ -1,0 +1,74 @@
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class DampLayout2DEnergyTest {
+    @Test
+    fun `обмен схожих кодов меняет энергию шагов DAML`() {
+        val codes = listOf(
+            intArrayOf(1, 1, 0, 0),
+            intArrayOf(1, 0, 1, 0),
+            intArrayOf(1, 1, 0, 0),
+        )
+        val layout = DampLayout2D(codes)
+
+        val heightField = layout.javaClass.getDeclaredField("height").apply { isAccessible = true }
+        val widthField = layout.javaClass.getDeclaredField("width").apply { isAccessible = true }
+        val gridField = layout.javaClass.getDeclaredField("grid").apply { isAccessible = true }
+        val positionsField = layout.javaClass.getDeclaredField("positions").apply { isAccessible = true }
+
+        heightField.setInt(layout, 2)
+        widthField.setInt(layout, 2)
+
+        val grid = arrayOf(
+            arrayOf<Int?>(0, 2),
+            arrayOf<Int?>(1, null),
+        )
+        gridField.set(layout, grid)
+
+        val positions = arrayOf(
+            intArrayOf(0, 0),
+            intArrayOf(1, 0),
+            intArrayOf(0, 1),
+        )
+        positionsField.set(layout, positions)
+
+        val lambda = 0.5
+        val longRange = layout.javaClass.getDeclaredMethod(
+            "computeLongRangeEnergy",
+            Int::class.javaObjectType,
+            Int::class.javaPrimitiveType,
+            Int::class.javaPrimitiveType,
+            Int::class.javaObjectType,
+            Int::class.javaPrimitiveType,
+            Int::class.javaPrimitiveType,
+            Double::class.javaPrimitiveType,
+        ).apply { isAccessible = true }
+
+        val currentLong = longRange.invoke(layout, 0, 0, 0, 1, 1, 0, lambda) as Double
+        val swappedLong = longRange.invoke(layout, 1, 0, 0, 0, 1, 0, lambda) as Double
+        assertTrue(
+            swappedLong > currentLong,
+            "После обмена схожие коды оказываются дальше и энергия дальнего этапа растёт",
+        )
+
+        val radius = 1.5
+        val shortRange = layout.javaClass.getDeclaredMethod(
+            "computeShortRangeEnergy",
+            Int::class.javaObjectType,
+            Int::class.javaPrimitiveType,
+            Int::class.javaPrimitiveType,
+            Int::class.javaObjectType,
+            Int::class.javaPrimitiveType,
+            Int::class.javaPrimitiveType,
+            Double::class.javaPrimitiveType,
+            Double::class.javaPrimitiveType,
+        ).apply { isAccessible = true }
+
+        val currentShort = shortRange.invoke(layout, 0, 0, 0, 1, 1, 0, lambda, radius) as Double
+        val swappedShort = shortRange.invoke(layout, 1, 0, 0, 0, 1, 0, lambda, radius) as Double
+        assertTrue(
+            swappedShort < currentShort,
+            "Ближний этап стремится оставить схожие коды в более выгодной конфигурации",
+        )
+    }
+}

--- a/src/test/kotlin/DampLayoutPinwheelOrderingTest.kt
+++ b/src/test/kotlin/DampLayoutPinwheelOrderingTest.kt
@@ -1,0 +1,64 @@
+import kotlin.math.atan2
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class DampLayoutPinwheelOrderingTest {
+    @Test
+    fun `углы располагаются по кругу`() {
+        val encoder = SlidingWindowAngleEncoder(
+            initialLayers = listOf(
+                SlidingWindowAngleEncoder.Layer(90.0, 4, 0.4),
+                SlidingWindowAngleEncoder.Layer(45.0, 8, 0.4),
+                SlidingWindowAngleEncoder.Layer(22.5, 16, 0.4),
+                SlidingWindowAngleEncoder.Layer(11.25, 32, 0.4),
+                SlidingWindowAngleEncoder.Layer(5.625, 64, 0.4),
+                SlidingWindowAngleEncoder.Layer(2.8125, 128, 0.4),
+            ),
+            initialCodeSizeInBits = 256
+        )
+        val samples = encoder.sampleFullCircle(stepDegrees = 1.0)
+        val layout = buildDampLayoutVisualization(samples)
+
+        val centerX = (layout.width - 1) / 2.0
+        val centerY = (layout.height - 1) / 2.0
+        val sorted = layout.points.sortedBy { it.angleDegrees }
+        val polarAngles = sorted.map { point ->
+            val dx = point.x - centerX
+            val dy = centerY - point.y
+            normalizeDegrees(Math.toDegrees(atan2(dy, dx)))
+        }
+
+        val offset = normalizeDegrees(polarAngles.first() - sorted.first().angleDegrees)
+        var maxDeviation = 0.0
+        var previousWrapped = normalizeDegrees(polarAngles.first() - offset)
+        for (index in sorted.indices) {
+            val targetAngle = sorted[index].angleDegrees
+            val polarWrapped = normalizeDegrees(polarAngles[index] - offset)
+            val deviation = angularDistance(polarWrapped, targetAngle)
+            if (deviation > maxDeviation) {
+                maxDeviation = deviation
+            }
+            if (index == 0) continue
+
+            var delta = polarWrapped - previousWrapped
+            while (delta < -1e-6) {
+                delta += 360.0
+            }
+            assertTrue(delta >= -1e-6, "Полярный угол должен возрастать монотонно")
+            previousWrapped = polarWrapped
+        }
+
+        assertTrue(maxDeviation < 15.0, "Максимальное отклонение $maxDeviation превышает 15°")
+    }
+}
+
+private fun angularDistance(first: Double, second: Double): Double {
+    val diff = kotlin.math.abs(normalizeDegrees(first - second))
+    return kotlin.math.min(diff, 360.0 - diff)
+}
+
+private fun normalizeDegrees(angle: Double): Double {
+    var result = angle % 360.0
+    if (result < 0.0) result += 360.0
+    return result
+}

--- a/src/test/kotlin/DampLayoutVisualizationTest.kt
+++ b/src/test/kotlin/DampLayoutVisualizationTest.kt
@@ -1,0 +1,26 @@
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DampLayoutVisualizationTest {
+    @Test
+    fun `раскладка возвращает 360 точек при шаге 1 градус`() {
+        val encoder = SlidingWindowAngleEncoder(
+            initialLayers = listOf(
+                SlidingWindowAngleEncoder.Layer(90.0, 4, 0.4),
+                SlidingWindowAngleEncoder.Layer(45.0, 8, 0.4),
+                SlidingWindowAngleEncoder.Layer(22.5, 16, 0.4),
+                SlidingWindowAngleEncoder.Layer(11.25, 32, 0.4),
+                SlidingWindowAngleEncoder.Layer(5.625, 64, 0.4),
+                SlidingWindowAngleEncoder.Layer(2.8125, 128, 0.4),
+            ),
+            initialCodeSizeInBits = 256
+        )
+
+        val samples = encoder.sampleFullCircle(stepDegrees = 1.0)
+        val layout = buildDampLayoutVisualization(samples)
+
+        assertEquals(360, layout.points.size, "Должно быть 360 кодов в раскладке")
+        assertTrue(layout.width > 0 && layout.height > 0, "Размеры раскладки должны быть положительными")
+    }
+}


### PR DESCRIPTION
## Что сделано
- реализован класс `DampLayout2D`, повторяющий этапы канонической 2D-раскладки из DAML
- добавлены настройки параметров порога, радиуса и этапов long-/short-range согласно статье

## Проверки
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68d7a0266c48832eb09063fa73186e44