### PR TITLE
Исправление обновления индексов в раскладке DAML

### DIFF
--- a/src/main/kotlin/DamlLongRangeLayout2D.kt
+++ b/src/main/kotlin/DamlLongRangeLayout2D.kt
@@ -25,16 +25,18 @@ class DamlLongRangeLayout2D(private val angleCodes: List<Pair<Double, IntArray>>
         if (angleCodes.isEmpty()) return emptyList()
         repeat(epochs.coerceAtLeast(0)) {
             for (firstIndex in grid.indices) {
-                val firstCodeIndex = grid[firstIndex] ?: continue
+                var currentFirstCodeIndex = grid[firstIndex] ?: continue
                 val secondCandidates = candidateIndices(firstIndex, farRadius)
                 for (secondIndex in secondCandidates) {
                     val secondCodeIndex = grid[secondIndex] ?: continue
-                    if (firstCodeIndex == secondCodeIndex) continue
+                    if (currentFirstCodeIndex == secondCodeIndex) continue
                     val currentEnergy = pairEnergy(firstIndex, secondIndex)
                     val swappedEnergy = swappedPairEnergy(firstIndex, secondIndex)
                     if (swappedEnergy < currentEnergy) {
+                        val previousFirstCodeIndex = currentFirstCodeIndex
                         grid[firstIndex] = secondCodeIndex
-                        grid[secondIndex] = firstCodeIndex
+                        currentFirstCodeIndex = secondCodeIndex
+                        grid[secondIndex] = previousFirstCodeIndex
                     }
                 }
             }

--- a/src/test/kotlin/DamlLongRangeLayout2DTest.kt
+++ b/src/test/kotlin/DamlLongRangeLayout2DTest.kt
@@ -1,0 +1,27 @@
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DamlLongRangeLayout2DTest {
+    @Test
+    fun `сетка сохраняет множество индексов после одной эпохи`() {
+        val angleCodes = listOf(
+            0.0 to intArrayOf(1, 0, 1),
+            45.0 to intArrayOf(0, 1, 0),
+            90.0 to intArrayOf(1, 1, 1),
+            135.0 to intArrayOf(0, 0, 0)
+        )
+        val layout = DamlLongRangeLayout2D(angleCodes)
+
+        layout.layout(farRadius = 2, epochs = 1)
+
+        val gridField = DamlLongRangeLayout2D::class.java.getDeclaredField("grid")
+        gridField.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        val grid = gridField.get(layout) as MutableList<Int?>
+
+        val actualIndices = grid.filterNotNull().toSet()
+        val expectedIndices = angleCodes.indices.toSet()
+
+        assertEquals(expectedIndices, actualIndices, "После обменов должны сохраниться все исходные индексы")
+    }
+}


### PR DESCRIPTION
## Изменения
- скорректировал алгоритм обмена в `DamlLongRangeLayout2D`, чтобы после успешной перестановки сохранялся актуальный индекс в первой позиции
- добавил модульный тест, проверяющий совпадение множеств индексов в решётке и исходном списке после одной эпохи

## Тесты
- `./gradlew test --console=plain --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68dba60c2aa0832eaf711f8883bcf7f0