### PR TITLE
Switch DampLayout2D to Proto-based inputs

### DIFF
--- a/src/main/kotlin/DampLayout2D.kt
+++ b/src/main/kotlin/DampLayout2D.kt
@@ -14,7 +14,7 @@ private const val MAX_CAND_PER_FIRST = 16       // ограничение чис
 private const val MAX_R_PER_DELTA     = 1000    // ограничение числа r в energyDelta
 
 class DampLayout2D(
-    private val codes: List<Pair<Double?, IntArray>>,
+    private val codes: List<Pair<Proto?, IntArray>>,
     randomizeStart: Boolean = true,
     seed: Int = 42,
 ) {
@@ -98,7 +98,7 @@ class DampLayout2D(
         log: Boolean = true,
         // если хочется ускорить: можно сразу задавать localEnergyRadius = farRadius
         forceLocalEnergyRadius: Int? = null,
-    ): List<Triple<Double?, Int, Int>> {
+    ): List<Triple<Proto?, Int, Int>> {
         if (n == 0) return emptyList()
 
         ensureNeighbors(farRadius)
@@ -434,13 +434,13 @@ class DampLayout2D(
 
     private fun toCoord(index: Int): Pair<Int, Int> = ys[index] to xs[index]
 
-    private fun buildCoordinateMap(): List<Triple<Double?, Int, Int>> {
-        val res = MutableList<Triple<Double?, Int, Int>>(n) { Triple(0.0, 0, 0) }
+    private fun buildCoordinateMap(): List<Triple<Proto?, Int, Int>> {
+        val res = MutableList<Triple<Proto?, Int, Int>>(n) { Triple(null, 0, 0) }
         grid.forEachIndexed { idx, codeIndex ->
             if (codeIndex == -1) return@forEachIndexed
-            val (angle, _) = codes[codeIndex]
+            val (proto, _) = codes[codeIndex]
             val (y, x) = toCoord(idx)
-            res[codeIndex] = Triple(angle, y, x)
+            res[codeIndex] = Triple(proto, y, x)
         }
         return res
     }
@@ -455,7 +455,7 @@ class DampLayout2D(
                 if (id == -1) {
                     "" // пустая ячейка
                 } else {
-                    val angle = codes[id].first
+                    val angle = codes[id].first?.angle
                     if (angle == null) {
                         ""
                     } else {

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -49,7 +49,7 @@ fun main() {
     )
 
 
-    val codes = mutableListOf<Pair<Double, IntArray>>()
+    val codes = mutableListOf<Pair<Proto, IntArray>>()
     var a = a0
     while (a < aN) {
         a += 1.0
@@ -65,7 +65,8 @@ fun main() {
                 val angleRad = toRadians(a)
                 val code = encoder.encode(angleRad, x, y)
                 println("$a:$x:$y\t" + code.joinToString("", "[", "]"))
-                codes += a to code
+                val proto = Proto(angle = a, x = x.toInt(), y = y.toInt())
+                codes += proto to code
             }
         }
 
@@ -77,7 +78,7 @@ fun main() {
 //    showSimilarityCurve(matrix, 0.0)
 
 
-    val emptyCodes: List<Pair<Double?, IntArray>> = (0..100).map { null to IntArray(encoder.codeSizeInBits) }
+    val emptyCodes: List<Pair<Proto?, IntArray>> = (0..100).map { null to IntArray(encoder.codeSizeInBits) }
 
     // CPU processing
     val cpuTime = measureTime {

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -65,7 +65,7 @@ fun main() {
                 val angleRad = toRadians(a)
                 val code = encoder.encode(angleRad, x, y)
                 println("$a:$x:$y\t" + code.joinToString("", "[", "]"))
-                val proto = Proto(angle = a, x = x.toInt(), y = y.toInt())
+                val proto = Proto(angle = a, x = x, y = y)
                 codes += proto to code
             }
         }

--- a/src/main/kotlin/Proto.kt
+++ b/src/main/kotlin/Proto.kt
@@ -1,0 +1,5 @@
+data class Proto(
+    val angle: Double,
+    val x: Int,
+    val y: Int,
+)

--- a/src/main/kotlin/Proto.kt
+++ b/src/main/kotlin/Proto.kt
@@ -1,5 +1,5 @@
 data class Proto(
     val angle: Double,
-    val x: Int,
-    val y: Int,
+    val x: Double,
+    val y: Double,
 )


### PR DESCRIPTION
## Summary
- add a Proto data class to hold angle and coordinates for encoded entries
- update DampLayout2D to accept Proto-based input pairs and log using prototype angles
- adjust the main generator to create Proto instances and propagate them through empty placeholders

## Testing
- ./gradlew test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ffc8331e4832e99c965f8cb5691a4)