### PR TITLE
Refactor encoder pipeline

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,115 +1,137 @@
 import SlidingWindowAngleEncoder.LinearLayer
 import SlidingWindowAngleEncoder.Layer
 import java.lang.Math.toRadians
-import kotlin.math.sqrt
+import kotlin.time.Duration
 import kotlin.time.measureTime
+
+private data class SweepRange(val start: Double, val endInclusive: Double, val step: Double) {
+    fun values(): Sequence<Double> = sequence {
+        var current = start
+        while (current <= endInclusive) {
+            yield(current)
+            current += step
+        }
+    }
+}
+
+private data class LayoutRunConfig(
+    val farRadiusFraction: Double = 0.5,
+    val epochs: Int = 100,
+    val lambdaStart: Double = 0.30,
+    val lambdaEnd: Double = 0.90,
+    val minSim: Double = 0.0,
+    val eta: Double = 0.0,
+    val maxBatchFrac: Double = 0.30,
+    val forceLocalEnergyRadius: Int? = null,
+)
 
 fun main() {
     println("os.arch=" + System.getProperty("os.arch"))
 
-    val a0 = 0.0
-    val aN = 360.0
-    val x0 = 0.0
-    val xN = 32.0
-    val y0 = 0.0
-    val yN = 32.0
+    val encoder = buildEncoder()
 
-    val encoder = SlidingWindowAngleEncoder(
-        // ---- ANGLE конфигурация ----
-        listOf(
-            Layer(120.0),
-            Layer(60.0),
-            Layer(30.0),
-            Layer(15.0),
-            Layer(5.0),
-//            Layer(2.5),
-//            Layer(1.0),
-        ),
-        // ---- X конфигурации ----
-        listOf(
-            LinearLayer(baseWidthUnits = 0.5,  overlapFraction = 0.4, domainMin = x0, domainMax = xN),
-            LinearLayer(baseWidthUnits = 1.0,  overlapFraction = 0.4, domainMin = x0, domainMax = xN),
-            LinearLayer(baseWidthUnits = 2.0,  overlapFraction = 0.4, domainMin = x0, domainMax = xN),
-            LinearLayer(baseWidthUnits = 4.0,  overlapFraction = 0.4, domainMin = x0, domainMax = xN),
-            LinearLayer(baseWidthUnits = 8.0,  overlapFraction = 0.4, domainMin = x0, domainMax = xN),
-            LinearLayer(baseWidthUnits = 16.0, overlapFraction = 0.4, domainMin = x0, domainMax = xN),
-//            LinearLayer(baseWidthUnits = 32.0, overlapFraction = 0.4, domainMin = x0, domainMax = xN),
-        ),
-        // ---- Y конфигурации ----
-        listOf(
-            LinearLayer(baseWidthUnits = 0.5,  overlapFraction = 0.4, domainMin = y0, domainMax = yN),
-            LinearLayer(baseWidthUnits = 1.0,  overlapFraction = 0.4, domainMin = y0, domainMax = yN),
-            LinearLayer(baseWidthUnits = 2.0,  overlapFraction = 0.4, domainMin = y0, domainMax = yN),
-            LinearLayer(baseWidthUnits = 4.0,  overlapFraction = 0.4, domainMin = y0, domainMax = yN),
-            LinearLayer(baseWidthUnits = 8.0,  overlapFraction = 0.4, domainMin = y0, domainMax = yN),
-            LinearLayer(baseWidthUnits = 16.0, overlapFraction = 0.4, domainMin = y0, domainMax = yN),
-//            LinearLayer(baseWidthUnits = 32.0, overlapFraction = 0.4, domainMin = y0, domainMax = yN),
-        ),
-        useRandomBitMapping = true,
-//        codeSizeInBits = 256
+    val angleRange = SweepRange(start = 1.0, endInclusive = 360.0, step = 1.0)
+    val xRange = SweepRange(start = 16.0, endInclusive = 32.0, step = 16.0)
+    val yRange = SweepRange(start = 16.0, endInclusive = 32.0, step = 16.0)
 
-    )
+    val codes = generateCodes(encoder, angleRange, xRange, yRange)
+    logCodes(codes)
 
-
-    val codes = mutableListOf<Pair<Proto, IntArray>>()
-    var a = a0
-    while (a < aN) {
-        a += 1.0
-
-        var x = x0
-        while (x < xN) {
-            x += 16.0
-
-            var y = y0
-            while (y < yN) {
-                y += 16.0
-
-                val angleRad = toRadians(a)
-                val code = encoder.encode(angleRad, x, y)
-                println("$a:$x:$y\t" + code.joinToString("", "[", "]"))
-                val proto = Proto(angle = a, x = x, y = y)
-                codes += proto to code
-            }
-        }
-
-    }
-
-
-//    val matrix = showAngleCodesCorrelationHeatmap(codes)
-//    val matrix = buildCodeCorrelationMatrix(codes)
-//    showSimilarityCurve(matrix, 0.0)
-
-
-    val emptyCodes: List<Pair<Proto?, IntArray>> = (0..100).map { null to IntArray(encoder.codeSizeInBits) }
-
-    // CPU processing
+    val emptyCodes = createEmptyCodes(codeSize = encoder.codeSizeInBits, count = 100)
     val layout = DampLayout2D(codes + emptyCodes)
 
-    val cpuTime = measureTime {
+    val layoutConfig = LayoutRunConfig()
+    val layoutDuration = runLayout(layout, layoutConfig)
 
-        val outCPU = layout.layoutLongRange(
-            farRadius = layout.gridSize / 2,
-            epochs = 100,
-            minSim = 0.0,
-            lambdaStart = 0.30,
-            lambdaEnd = 0.90,
-            eta = 0.0,
-            maxBatchFrac = 0.30,
-            log = true
-        )
+    logSimilarities(layout)
+    println("CPU Layout finished! Total time: $layoutDuration")
+}
+
+private fun buildEncoder(): SlidingWindowAngleEncoder {
+    val angleLayers = listOf(
+        Layer(120.0),
+        Layer(60.0),
+        Layer(30.0),
+        Layer(15.0),
+        Layer(5.0),
+    )
+
+    val xLayers = listOf(
+        LinearLayer(baseWidthUnits = 0.5, overlapFraction = 0.4, domainMin = 0.0, domainMax = 32.0),
+        LinearLayer(baseWidthUnits = 1.0, overlapFraction = 0.4, domainMin = 0.0, domainMax = 32.0),
+        LinearLayer(baseWidthUnits = 2.0, overlapFraction = 0.4, domainMin = 0.0, domainMax = 32.0),
+        LinearLayer(baseWidthUnits = 4.0, overlapFraction = 0.4, domainMin = 0.0, domainMax = 32.0),
+        LinearLayer(baseWidthUnits = 8.0, overlapFraction = 0.4, domainMin = 0.0, domainMax = 32.0),
+        LinearLayer(baseWidthUnits = 16.0, overlapFraction = 0.4, domainMin = 0.0, domainMax = 32.0),
+    )
+
+    val yLayers = listOf(
+        LinearLayer(baseWidthUnits = 0.5, overlapFraction = 0.4, domainMin = 0.0, domainMax = 32.0),
+        LinearLayer(baseWidthUnits = 1.0, overlapFraction = 0.4, domainMin = 0.0, domainMax = 32.0),
+        LinearLayer(baseWidthUnits = 2.0, overlapFraction = 0.4, domainMin = 0.0, domainMax = 32.0),
+        LinearLayer(baseWidthUnits = 4.0, overlapFraction = 0.4, domainMin = 0.0, domainMax = 32.0),
+        LinearLayer(baseWidthUnits = 8.0, overlapFraction = 0.4, domainMin = 0.0, domainMax = 32.0),
+        LinearLayer(baseWidthUnits = 16.0, overlapFraction = 0.4, domainMin = 0.0, domainMax = 32.0),
+    )
+
+    return SlidingWindowAngleEncoder(
+        layers = angleLayers,
+        xLayers = xLayers,
+        yLayers = yLayers,
+        useRandomBitMapping = true,
+    )
+}
+
+private fun generateCodes(
+    encoder: SlidingWindowAngleEncoder,
+    angleRange: SweepRange,
+    xRange: SweepRange,
+    yRange: SweepRange,
+): List<Pair<Proto, IntArray>> {
+    val codes = mutableListOf<Pair<Proto, IntArray>>()
+    angleRange.values().forEach { angleDegrees ->
+        val angleRad = toRadians(angleDegrees)
+        xRange.values().forEach { x ->
+            yRange.values().forEach { y ->
+                val code = encoder.encode(angleRad, x, y)
+                codes += Proto(angleDegrees, x, y) to code
+            }
+        }
     }
-    val sim1 = layout.jaccardSimilarity(
-        Proto(289.0, 16.0, 32.0),
-        Proto(107.0, 16.0, 16.0)
+    return codes
+}
+
+private fun logCodes(codes: List<Pair<Proto, IntArray>>) {
+    codes.forEach { (proto, code) ->
+        println("${proto.angle}:${proto.x}:${proto.y}\t" + code.joinToString("", "[", "]"))
+    }
+}
+
+private fun createEmptyCodes(codeSize: Int, count: Int): List<Pair<Proto?, IntArray>> =
+    (0 until count).map { null to IntArray(codeSize) }
+
+private fun runLayout(layout: DampLayout2D, config: LayoutRunConfig): Duration = measureTime {
+    val farRadius = (layout.gridSize * config.farRadiusFraction).toInt().coerceAtLeast(1)
+    layout.layoutLongRange(
+        farRadius = farRadius,
+        epochs = config.epochs,
+        minSim = config.minSim,
+        lambdaStart = config.lambdaStart,
+        lambdaEnd = config.lambdaEnd,
+        eta = config.eta,
+        maxBatchFrac = config.maxBatchFrac,
+        log = true,
+        forceLocalEnergyRadius = config.forceLocalEnergyRadius,
     )
-    println("sim1 = $sim1")
+}
 
-    val sim2 = layout.jaccardSimilarity(
-        Proto(96.0, 16.0, 16.0),
-        Proto(102.0, 16.0, 16.0)
+private fun logSimilarities(layout: DampLayout2D) {
+    val pairs = listOf(
+        Proto(289.0, 16.0, 32.0) to Proto(107.0, 16.0, 16.0),
+        Proto(96.0, 16.0, 16.0) to Proto(102.0, 16.0, 16.0),
     )
-    println("sim2 = $sim2")
-
-    println("CPU Layout finished! Total time: $cpuTime")
-
+    pairs.forEachIndexed { idx, (first, second) ->
+        val similarity = layout.jaccardSimilarity(first, second)
+        println("sim${idx + 1} = $similarity")
+    }
 }

--- a/src/main/kotlin/SlidingWindowAngleEncoder.kt
+++ b/src/main/kotlin/SlidingWindowAngleEncoder.kt
@@ -63,8 +63,26 @@ class SlidingWindowAngleEncoder(
             ((domainMax - domainMin) / baseWidthUnits).roundToInt().coerceAtLeast(1)
     }
 
+    private data class PeriodicLayerGeometry(
+        val windowHalfWidth: Double,
+        val step: Double,
+        val offset: Double,
+        val detectorCount: Int,
+        val logicalOffset: Int,
+    )
+
+    private data class LinearLayerGeometry(
+        val domainMin: Double,
+        val domainMax: Double,
+        val windowHalfWidth: Double,
+        val step: Double,
+        val phaseShift: Double,
+        val detectorCount: Int,
+        val logicalOffset: Int,
+    )
+
     // --------- константы ---------
-    val twoPi: Double = 2.0 * PI
+    private val twoPi: Double = 2.0 * PI
     private val degreesToRadians: Double = PI / 180.0
 
     /** Общее число детекторов (ANG + X + Y) в логическом пространстве. */
@@ -79,10 +97,20 @@ class SlidingWindowAngleEncoder(
      */
     private val detectorToBitIndex: IntArray
 
+    /** Подготовленные параметры геометрии для угловых слоёв. */
+    private val angularGeometry: List<PeriodicLayerGeometry>
+
+    /** Подготовленные параметры геометрии для линейных слоёв X/Y. */
+    private val xGeometry: List<LinearLayerGeometry>
+    private val yGeometry: List<LinearLayerGeometry>
+
     /** Последний код (для отладки). */
     var lastEncodedCode: IntArray = IntArray(0); private set
 
     init {
+        validateAngleLayers(layers)
+        validateLinearLayersNonEmpty(xLayers, "X")
+        validateLinearLayersNonEmpty(yLayers, "Y")
         validateCodeSize(codeSizeInBits, layers, xLayers, yLayers)
 
         detectorToBitIndex = if (useRandomBitMapping) {
@@ -94,6 +122,10 @@ class SlidingWindowAngleEncoder(
         } else {
             IntArray(totalDetectorsCount) { it } // детектор d -> бит d
         }
+
+        angularGeometry = buildAngularGeometry(layers)
+        xGeometry = buildLinearGeometry(xLayers)
+        yGeometry = buildLinearGeometry(yLayers)
     }
 
     // ----------------- Публичное API -----------------
@@ -105,38 +137,10 @@ class SlidingWindowAngleEncoder(
             "codeSizeInBits=$codeSizeInBits меньше требуемых $totalBits бит"
         }
         val out = IntArray(codeSizeInBits)
-        var logicalOffset = 0 // смещение в логическом пространстве детекторов
 
-        // ---- ANGLE ----
-        if (layers.isNotEmpty()) {
-            var ang = angleInRadians % twoPi
-            if (ang < 0.0) ang += twoPi
-            val layerCount = layers.size
-            layers.forEachIndexed { idx, layer ->
-                val win = layer.arcLengthDegrees * (1.0 + layer.overlapFraction) * degreesToRadians
-                val half = win / 2.0
-                val step = layer.arcLengthDegrees * degreesToRadians
-                val phase = (idx.toDouble() / layerCount) * step
-                val offsetRad = layer.offsetDegrees * degreesToRadians
-                for (d in 0 until layer.detectorCount) {
-                    val center = d * step + phase + offsetRad
-                    val sRaw = center - half
-                    val eRaw = center + half
-                    var s = sRaw % twoPi; if (s < 0.0) s += twoPi
-                    var e = eRaw % twoPi; if (e < 0.0) e += twoPi
-                    val hit = if (s <= e) (ang >= s && ang < e) else (ang >= s || ang < e)
-                    if (hit) setDetectorBit(logicalOffset + d, out)
-                }
-                logicalOffset += layer.detectorCount
-            }
-        }
-
-        // ---- X ----
-        encodeLinear1D(xLayers, x, out, logicalOffset)
-        logicalOffset += xLayers.sumOf { it.detectorCount }
-
-        // ---- Y ----
-        encodeLinear1D(yLayers, y, out, logicalOffset)
+        encodeAngle(angleInRadians, out)
+        encodeLinear(x, xGeometry, out)
+        encodeLinear(y, yGeometry, out)
 
         lastEncodedCode = out
         return out
@@ -152,32 +156,89 @@ class SlidingWindowAngleEncoder(
         out[bitIndex] = 1
     }
 
-    private fun encodeLinear1D(
-        layers: List<LinearLayer>,
-        value: Double,
-        out: IntArray,
-        logicalBitOffset: Int
-    ) {
-        var logicalOffset = logicalBitOffset
-        val layerCount = layers.size
-        layers.forEachIndexed { idx, L ->
-            require(L.domainMax > L.domainMin) { "Некорректный домен линейного слоя: max<=min" }
-            val v = value.coerceIn(L.domainMin, L.domainMax)
-            val baseW = L.baseWidthUnits
-            val winW  = baseW * (1.0 + L.overlapFraction)
-            val halfW = winW / 2.0
-            val domainLen = L.domainMax - L.domainMin
-            val step = domainLen / L.detectorCount
-            val phase = (idx.toDouble() / layerCount) * step
-            for (d in 0 until L.detectorCount) {
-                val center = L.domainMin + d * step + phase
-                val s = center - halfW
-                val e = center + halfW
-                if (v >= s && v < e) {
-                    setDetectorBit(logicalOffset + d, out)
+    private fun encodeAngle(angleInRadians: Double, out: IntArray) {
+        if (angularGeometry.isEmpty()) return
+
+        var normalizedAngle = angleInRadians % twoPi
+        if (normalizedAngle < 0.0) normalizedAngle += twoPi
+
+        angularGeometry.forEach { geometry ->
+            repeat(geometry.detectorCount) { detectorIndex ->
+                val center = geometry.offset + detectorIndex * geometry.step
+                val startRaw = center - geometry.windowHalfWidth
+                var start = startRaw % twoPi; if (start < 0.0) start += twoPi
+                val endRaw = center + geometry.windowHalfWidth
+                var end = endRaw % twoPi; if (end < 0.0) end += twoPi
+
+                val hit = if (start <= end) {
+                    normalizedAngle >= start && normalizedAngle < end
+                } else {
+                    normalizedAngle >= start || normalizedAngle < end
+                }
+
+                if (hit) setDetectorBit(geometry.logicalOffset + detectorIndex, out)
+            }
+        }
+    }
+
+    private fun encodeLinear(value: Double, geometry: List<LinearLayerGeometry>, out: IntArray) {
+        if (geometry.isEmpty()) return
+
+        geometry.forEach { layer ->
+            val clamped = value.coerceIn(layer.domainMin, layer.domainMax)
+            repeat(layer.detectorCount) { detectorIndex ->
+                val center = layer.domainMin + detectorIndex * layer.step + layer.phaseShift
+                val start = center - layer.windowHalfWidth
+                val end = center + layer.windowHalfWidth
+
+                if (clamped >= start && clamped < end) {
+                    setDetectorBit(layer.logicalOffset + detectorIndex, out)
                 }
             }
-            logicalOffset += L.detectorCount
+        }
+    }
+
+    private fun buildAngularGeometry(layers: List<Layer>): List<PeriodicLayerGeometry> {
+        var logicalOffset = 0
+        val layerCount = layers.size.toDouble().takeIf { it > 0 } ?: return emptyList()
+
+        return layers.mapIndexed { idx, layer ->
+            val step = layer.arcLengthDegrees * degreesToRadians
+            val win = step * (1.0 + layer.overlapFraction)
+            val half = win / 2.0
+            val phase = (idx.toDouble() / layerCount) * step
+            val offset = phase + layer.offsetDegrees * degreesToRadians
+
+            PeriodicLayerGeometry(
+                windowHalfWidth = half,
+                step = step,
+                offset = offset,
+                detectorCount = layer.detectorCount,
+                logicalOffset = logicalOffset
+            ).also { logicalOffset += layer.detectorCount }
+        }
+    }
+
+    private fun buildLinearGeometry(layers: List<LinearLayer>): List<LinearLayerGeometry> {
+        var logicalOffset = 0
+        val layerCount = layers.size.toDouble().takeIf { it > 0 } ?: return emptyList()
+
+        return layers.mapIndexed { idx, layer ->
+            val winWidth = layer.baseWidthUnits * (1.0 + layer.overlapFraction)
+            val half = winWidth / 2.0
+            val domainLen = layer.domainMax - layer.domainMin
+            val step = domainLen / layer.detectorCount
+            val phase = (idx.toDouble() / layerCount) * step
+
+            LinearLayerGeometry(
+                domainMin = layer.domainMin,
+                domainMax = layer.domainMax,
+                windowHalfWidth = half,
+                step = step,
+                phaseShift = phase,
+                detectorCount = layer.detectorCount,
+                logicalOffset = logicalOffset
+            ).also { logicalOffset += layer.detectorCount }
         }
     }
 


### PR DESCRIPTION
## Summary
- refactor the entrypoint into reusable helpers for encoder construction, sweep ranges, and layout execution
- streamline SlidingWindowAngleEncoder by precomputing geometry and validating layers before encoding
- keep similarity logging and placeholder code generation organized for DAML-style experiments

## Testing
- ./gradlew test --console=plain


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920418897d8832e82c9fde0e4941e55)